### PR TITLE
Added pt-br langcode

### DIFF
--- a/lang/langnames.txt
+++ b/lang/langnames.txt
@@ -131,6 +131,7 @@ pi	पाऴि
 pl	Polski
 ps	پښتو
 pt	Português
+pt-br   Português
 qu	Runa Simi
 rm	Rumantsch Grischun
 rn	KiRundi


### PR DESCRIPTION
Hi, in my wiki (http://wiki.filipesaraiva.info/doku.php), in Languages menu, Português appeared as pt-br only. So, I added pt-br and Português to langname file and fix it. I think that its a bug. My pull request fix it. Thanks for this great plugin!
