### PR TITLE
Fix for translation links in some scenarios

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -94,10 +94,10 @@ class helper_plugin_translation extends DokuWiki_Plugin {
     function buildTransID($lng, $idpart) {
         global $conf;
         if($lng) {
-            $link = ':' . $this->tns . $lng . ':' . $idpart;
+            $link = ':' . $this->tns . $lng . ':' . preg_replace("/^{$this->tns}/", "", $idpart);
             $name = $lng;
         } else {
-            $link = ':' . $this->tns . $idpart;
+            $link = ':' . $this->tns . preg_replace("/^{$this->tns}/", "", $idpart);
             $name = $this->realLC('');
         }
         return array($link, $name);


### PR DESCRIPTION
When translations are restricted to a namespace, and the plugin is installed using option 1 (original language
has no namespace prefix), links were generated incorrectly.
Fixes issue #61 for me!
