### PR TITLE
Made position of lang-code configurable

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -16,3 +16,5 @@ $conf['about']         = '';
 $conf['localabout']    = 0;
 $conf['display']       = 'langcode,title';
 $conf['copytrans']     = 0;
+
+$conf['langcodeat']    = 'root';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -17,4 +17,5 @@ $meta['checkage']      = array('onoff');
 $meta['about']         = array('string','_pattern' => '/^(|[\w:\-]+)$/');
 $meta['localabout']    = array('onoff');
 $meta['copytrans']     = array('onoff');
-
+$meta['langcodeat']    = array('multichoice',
+                                '_choices' => array('root','lastns'));

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -17,3 +17,8 @@ $lang['checkage']      = 'Warn about possibly outdated translations.';
 $lang['display']       = 'Select what you\'d like to have shown in the language selector. Note that using country flags for language selection is not recommended by usability experts.';
 
 $lang['copytrans']     = 'Copy original language text into the editor when starting a new translation?';
+$lang['langcodeat']    = 'Position of namespace for language codes.';
+$lang['langcodeat_o_root']
+                       = 'at root (after translationns, if exists)';
+$lang['langcodeat_o_lastns']
+                       = 'after the last namespace (just before page name)';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -2,8 +2,9 @@
 
 /**
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * 
+ *
  * @author Hideaki SAWADA <chuno@live.jp>
+ * @author Ikuo Obataya <i.obataya@gmail.com>
  */
 $lang['translations']          = '翻訳言語（ISOコード）のスペース区切り一覧';
 $lang['translationns']         = '特定の名前空間以下のみを翻訳したい場合、名前空間を記入する。';
@@ -16,3 +17,8 @@ $lang['localabout']            = '（包括的な概要ページの代わりに�
 $lang['checkage']              = '古い翻訳について警告する。';
 $lang['display']               = '言語セレクタに何を表示するかを選択する。言語選択に国旗を使用することをユーザビリティ専門家は奨励しないので注意してください。';
 $lang['copytrans']             = '新しく翻訳を開始する時、エディタに元の言語の文章をコピーするか？';
+$lang['langcodeat']            = '言語コードの名前空間はどこに置くか？';
+$lang['langcodeat_o_root']
+                               = 'root (translationnsが指定されていたらその後)';
+$lang['langcodeat_o_lastns']
+                               = '最後の名前空間の後 (ページ名の直前)';


### PR DESCRIPTION
This modification enables users to configure positions of lang-code.

For example, users can choose two modes as follows.
- **at root** - default setting
  - translationNS:NS1:NS2:pagename (default lang)
  - translationNS:**de**:NS1:NS2:pagename
  - translationNS:**ja**:NS1:NS2:pagename
- **after the last namespace**
  - translationNS:NS1:NS2:pagename (default lang)
  - translationNS:NS1:NS2:**de**:pagename
  - translationNS:NS1:NS2:**ja**:pagename
