### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -33,7 +33,7 @@ class action_plugin_translation extends DokuWiki_Action_Plugin {
     /**
      * Register the events
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $scriptName = basename($_SERVER['PHP_SELF']);
 
         // should the lang be applied to UI?

--- a/syntax/notrans.php
+++ b/syntax/notrans.php
@@ -48,14 +48,14 @@ class syntax_plugin_translation_notrans extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         return array('notrans');
     }
 
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         // store info in metadata
         if($format == 'metadata'){
             $renderer->meta['plugin']['translation']['notrans'] = true;

--- a/syntax/trans.php
+++ b/syntax/trans.php
@@ -33,14 +33,14 @@ class syntax_plugin_translation_trans extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array();
     }
 
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if($format != 'xhtml') return false;
 
         // disable caching


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.