### PR TITLE
Styling: Add cur class to surrounding div as well

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -297,10 +297,12 @@ class helper_plugin_translation extends DokuWiki_Plugin {
         // local language name
         $localname = $this->getLocalName($lang);
 
+        $divClass = 'li';
         // current?
         if($ID == $link) {
             $sel = ' selected="selected"';
             $class .= ' cur';
+            $divClass .= ' cur';
         } else {
             $sel = '';
         }
@@ -331,7 +333,7 @@ class helper_plugin_translation extends DokuWiki_Plugin {
             $out .= $display;
             $out .= '</option>';
         } else {
-            $out .= '<li><div class="li">';
+            $out .= "<li><div class='$divClass'>";
             $out .= '<a href="' . wl($link) . '" class="' . $class . '" title="' . hsc($localname) . '">';
             if($flag) $out .= '<img src="' . $flag . '" alt="' . hsc($lang) . '" height="11" />';
             $out .= $display;


### PR DESCRIPTION
To be able to style the translation-buttons better, it would be helpful if we had the `cur`-class on the surrounding `<div>` as well.

I keep the `cur`-class on the `<a>` tag for backward compatibility with existing styles.