### PR TITLE
Translate the ui of the detail-page as well

### DIFF
--- a/action.php
+++ b/action.php
@@ -61,6 +61,7 @@ class action_plugin_translation extends DokuWiki_Action_Plugin {
 
         if($scriptName !== 'js.php' && $scriptName !== 'ajax.php') {
             $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'translation_hook');
+            $controller->register_hook('DETAIL_STARTED', 'BEFORE', $this, 'translation_hook');
             $controller->register_hook('MEDIAMANAGER_STARTED', 'BEFORE', $this, 'translation_hook');
         }
 


### PR DESCRIPTION
Currently, the translations of the Detail-Page are always in the default language. This adds the detail-page to the list of routes that may get their language-files adjusted.