### PR TITLE
Use default language when lang_before_translation is empty

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -39,7 +39,7 @@ class helper_plugin_translation extends DokuWiki_Plugin {
         $this->opts = array_fill_keys($this->opts, true);
 
         // get default translation
-        if(!empty($conf['lang_before_translation'])) {
+        if(empty($conf['lang_before_translation'])) {
             $dfl = $conf['lang'];
         } else {
             $dfl = $conf['lang_before_translation'];


### PR DESCRIPTION
This should fix a bug introduced by commit 9cf46baabdee5a82c443dd10c535a587c360beb9