### PR TITLE
Apply cleanID() on $translatedStartpage before redirecting.

### DIFF
--- a/_test/basic.test.php
+++ b/_test/basic.test.php
@@ -59,7 +59,7 @@ class basic_plugin_translation_test extends DokuWikiTest {
                 'start',
                 'de es',
                 'de,en-US;q=0.8,en;q=0.5,fr;q=0.3',
-                ':de:start',
+                'de:start',
                 'redirect to translated page',
             ),
             array(

--- a/action.php
+++ b/action.php
@@ -223,7 +223,7 @@ class action_plugin_translation extends DokuWiki_Action_Plugin {
 
             list($translatedStartpage,) = $this->helper->buildTransID($lc, $conf['start']);
             if (cleanID($translatedStartpage) !== cleanID($ID)) {
-                send_redirect(wl($translatedStartpage, '', true));
+                send_redirect(wl(cleanID($translatedStartpage), '', true));
             }
         }
 


### PR DESCRIPTION
Fixes #137