### PR TITLE
The dropdown should follow `userewrite` URLs + Hreflang Support

### DIFF
--- a/action.php
+++ b/action.php
@@ -67,6 +67,33 @@ class action_plugin_translation extends DokuWiki_Action_Plugin {
 
         $controller->register_hook('SEARCH_QUERY_PAGELOOKUP', 'AFTER', $this, 'translation_search');
         $controller->register_hook('COMMON_PAGETPL_LOAD', 'AFTER', $this, 'page_template_replacement');
+        $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'inject_hreflangs');
+    }
+
+    /**
+     * Tell search engines about all localized version of the current page
+     * @see https://en.wikipedia.org/wiki/Hreflang
+     *
+     * @param Doku_Event $event
+     * @param $args
+     */
+    public function inject_hreflangs(Doku_Event $event, $args)
+    {
+        global $ID;
+
+        list($lc, $idpart) = $this->helper->getTransParts($ID);
+        foreach ($this->helper->translations as $iso) {
+            $trans_id = $this->helper->buildTransID($iso, $idpart);
+
+            $translated_id = cleanID($trans_id[0]);
+            if (page_exists($translated_id)) {
+                $event->data['link'][] = array(
+                    'rel' => 'alternate',
+                    'hreflang' => $iso,
+                    'href' => wl($translated_id, '', true),
+                );
+            }
+        }
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -357,9 +357,7 @@ class helper_plugin_translation extends DokuWiki_Plugin {
         // prepare output
         $out = '';
         if($this->getConf('dropdown')) {
-            if($conf['useslash']) $link = str_replace(':', '/', $link);
-
-            $out .= '<option class="' . $class . '" title="' . hsc($localname) . '" value="' . $link . '"' . $sel . $style . '>';
+            $out .= '<option class="' . $class . '" title="' . hsc($localname) . '" value="' . wl($link) . '"' . $sel . $style . '>';
             $out .= $display;
             $out .= '</option>';
         } else {

--- a/script.js
+++ b/script.js
@@ -6,15 +6,6 @@ jQuery(function(){
     if(!$frm.length) return;
     $frm.find('input[name=go]').hide();
     $frm.find('select[name=id]').change(function(){
-        var id = jQuery(this).val();
-        // this should hopefully detect rewriting good enough:
-        var action = $frm.attr('action');
-        if(action.substr(action.length-1) == '/'){
-            var link = action + id;
-        }else{
-            var link = action + '?id=' + id;
-        }
-
-        window.location.href= link;
+        location.href = this.value;
     });
 });


### PR DESCRIPTION
I'm using a multilingual wiki, where all languages are in sub namespaces. My configuration:
```
$conf['start'] = 'index';
$conf['userewrite'] = '1';
$conf['plugin']['translation']['dropdown'] = 1;
```

Homepage URLs are looking as follows:
```
example.com/en/index
example.com/fr/index
example.com/ru/index
```

The problem is that switching languages from dropdown redirect me to:
`example.com/index?id=en/index`

Since disabling the language dropdown (i.e., `$conf['plugin']['translation']['dropdown'] = 0`) displays proper URLs, I think it would be nice to take advantage of this.
