### PR TITLE
admin page: fix incorrectly inverted conditional

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -36,7 +36,7 @@ class admin_plugin_translation extends DokuWiki_Admin_Plugin {
 
         $pages = $this->getAllPages();
         foreach ($pages as $page) {
-            if (!$helper->getLangPart($page["id"]) === $default_language ||
+            if ($helper->getLangPart($page["id"]) !== $default_language ||
                 !$helper->istranslatable($page["id"], false) ||
                 !page_exists($page["id"])
             ) {


### PR DESCRIPTION
The operator precedence of `!` is higher than `===`, so commit https://github.com/splitbrain/dokuwiki-plugin-translation/commit/bcbb210f3744a804568845f6a65e23d1a4fe0303 inverted the conditional incorrectly.

Either parens are required, or we use `!==`, which seems a little more clear to me.

See also https://www.php.net/manual/en/language.operators.precedence.php