### PR TITLE
added check for missing HTTP_ACCEPT_LANGUAGE and minor change in de translation

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -100,7 +100,11 @@ class helper_plugin_translation extends Plugin
     public function getBrowserLang()
     {
         global $conf;
-        $langs = $this->translations;
+        // Check if HTTP_ACCEPT_LANGUAGE header exists
+        if (!isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) || empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+            return false;
+        }
+            $langs = $this->translations;
         if (!in_array($conf['lang'], $langs)) {
             $langs[] = $conf['lang'];
         }
@@ -110,6 +114,7 @@ class helper_plugin_translation extends Plugin
         }
         return false;
     }
+
 
     /**
      * Returns the ID and name to the wanted translation, empty

--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -10,7 +10,7 @@ $lang['outdated']              = 'Diese Übersetzung ist älter als das <a href=
 $lang['diff']                  = '<a href="%s" class="wikilink1">Änderungen</a> zeigen.';
 $lang['transloaded']           = 'Der Inhalt dieser Seite auf %s wurde in den Editor geladen um die Übersetzung zu erleichtern.<br />Du kannst deine Arbeit auch mit einer der folgenden vorhandenen Übersetzungen beginnen: %s.';
 $lang['menu']                  = 'veraltete und fehlende Übersetzungen';
-$lang['missing']               = 'Fehlt!';
+$lang['missing']               = 'fehlt!';
 $lang['old']                   = 'veraltet';
 $lang['current']               = 'aktuell';
 $lang['path']                  = 'Pfad';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -10,7 +10,7 @@ $lang['outdated']              = 'Diese Übersetzung ist älter als das <a href=
 $lang['diff']                  = '<a href="%s" class="wikilink1">Änderungen</a> zeigen.';
 $lang['transloaded']           = 'Der Inhalt dieser Seite auf %s wurde in den Editor geladen um die Übersetzung zu erleichtern.<br />Sie können Ihre Arbeit auch mit einer der folgenden vorhandenen Übersetzungen beginnen: %s.';
 $lang['menu'] = "veraltete und fehlende Übersetzungen";
-$lang['missing']               = 'Fehlt!';
+$lang['missing']               = 'fehlt!';
 $lang['old']                   = 'veraltet';
 $lang['current']               = 'aktuell';
 $lang['path']                  = 'Pfad';


### PR DESCRIPTION
Added check for missing HTTP_ACCEPT_LANGUAGE. Some Browsers and Bots are not sendig this header. This results in many errors in the DokuWiki-Log.

minor change in de translation: "Fehlt" changed to "fehlt" to be consistent with the other words that are lowercased.