### PR TITLE
fix Undefined array key

### DIFF
--- a/action.php
+++ b/action.php
@@ -213,15 +213,20 @@ class action_plugin_translation extends ActionPlugin
     public function handlePageTemplates(Event $event)
     {
         global $ID;
+        global $INPUT;
 
         // load orginal content as template?
         if ($this->getConf('copytrans') && $this->helper->istranslatable($ID, false)) {
             // look for existing translations
             $translations = $this->helper->getAvailableTranslations($ID);
+
             if ($translations) {
                 // find original language (might've been provided via parameter or use first translation)
-                $orig = (string)$_REQUEST['fromlang'];
-                if (!$orig) $orig = array_key_first($translations);
+                $orig = $INPUT->str('fromlang', '');
+
+                if (!$orig || !array_key_exists($orig, $translations)) {
+                    $orig = array_key_first($translations);
+                }
 
                 // load file
                 $origfile = $translations[$orig];


### PR DESCRIPTION
## Summary

This fixes a PHP warning in `handlePageTemplates()` when the `fromlang` request parameter is missing while creating a new translated page.

## Problem

When `copytrans` is enabled and a new translation page is created, the plugin tries to read the source language from:

```php
$_REQUEST['fromlang']
```

If the request does not contain fromlang, PHP 8 emits the following warning:
```text
Warning: Undefined array key "fromlang"
```
The existing logic already falls back to the first available translation when no source language is provided, but the warning is triggered before the fallback can happen.

## Fix
Use DokuWiki's ``$INPUT->str()`` helper to read the optional ``fromlang`` parameter with a default empty value.
Additionally, validate that the requested source language actually exists in the available translations before using it.